### PR TITLE
Extract merge helpers and add JSON merging script

### DIFF
--- a/merge_jsons.py
+++ b/merge_jsons.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Merge page-level JSON checkpoints produced by :mod:`gemini`."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from merge_utils import apply_continuation_if_any, apply_page_lead_if_any
+
+LOG = logging.getLogger("merge_jsons")
+PAGE_FILE_RE = re.compile(r"^(?P<stem>.+)_p(?P<page>\d{5})$")
+
+
+def setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def find_page_files(jsons_dir: Path, stem: Optional[str]) -> List[Tuple[str, int, Path]]:
+    """Return ``(stem, page, path)`` tuples for per-page checkpoint files."""
+    files: List[Tuple[str, int, Path]] = []
+    for path in sorted(jsons_dir.glob("*.json")):
+        match = PAGE_FILE_RE.match(path.stem)
+        if not match:
+            continue
+        match_stem = match.group("stem")
+        if stem and match_stem != stem:
+            continue
+        page = int(match.group("page"))
+        files.append((match_stem, page, path))
+    files.sort(key=lambda x: x[1])
+    return files
+
+
+def load_page_objects(path: Path) -> List[dict]:
+    text = path.read_text(encoding="utf-8")
+    data = json.loads(text)
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return data
+    raise ValueError(f"JSON file {path} did not contain an object or array.")
+
+
+def detect_image_name(page_objs: Sequence[dict]) -> Optional[str]:
+    for obj in page_objs:
+        if not isinstance(obj, dict):
+            continue
+        src = obj.get("source")
+        if isinstance(src, dict):
+            img = src.get("fileName")
+            if isinstance(img, str):
+                return img
+    return None
+
+
+def write_atomic_json(path: Path, payload: object) -> None:
+    tmp = path.with_suffix(path.suffix + ".part")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def merge_pages(
+    entries: Sequence[Tuple[str, int, Path]],
+    capture_page_leads: bool,
+    page_leads_path: Optional[Path],
+    final_path: Path,
+) -> None:
+    merged: List[dict] = []
+    page_leads: Dict[int, dict] = {}
+
+    for stem, page, path in entries:
+        page_objs = load_page_objects(path)
+        img_name = detect_image_name(page_objs)
+
+        if capture_page_leads:
+            page_objs = apply_page_lead_if_any(page_objs, page, img_name, page_leads)
+            if page in page_leads:
+                LOG.debug("Captured __PAGE__ sentinel for p%d (%s)", page, stem)
+
+        page_objs = apply_continuation_if_any(page_objs, merged)
+        merged.extend(page_objs)
+        LOG.info("Merged p%d from %s (%d object(s))", page, path.name, len(page_objs))
+
+    write_atomic_json(final_path, merged)
+    LOG.info("Wrote merged output → %s (%d objects)", final_path, len(merged))
+
+    if capture_page_leads and page_leads:
+        assert page_leads_path is not None
+        ordered = [page_leads[p] for p in sorted(page_leads)]
+        write_atomic_json(page_leads_path, ordered)
+        LOG.info(
+            "Wrote %d page-lead sentinel(s) → %s",
+            len(ordered),
+            page_leads_path,
+        )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Merge per-page JSON checkpoints into a final array.")
+    ap.add_argument("--jsons_dir", type=Path, default=Path("./jsons"))
+    ap.add_argument("--stem", type=str, default=None, help="Filter checkpoints to this PDF stem.")
+    ap.add_argument("--output", type=Path, default=Path("./final.json"), help="Merged JSON output path.")
+    ap.add_argument(
+        "--page_leads",
+        action="store_true",
+        help="Capture __PAGE__ sentinel objects into a sidecar file (removed from final merge).",
+    )
+    ap.add_argument(
+        "--page_leads_path",
+        type=Path,
+        default=None,
+        help="Explicit path for the page-leads sidecar. Defaults to <jsons>/<stem>.page_leads.json",
+    )
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args()
+
+    setup_logging(args.verbose)
+
+    if not args.jsons_dir.exists():
+        raise SystemExit(f"JSON directory not found: {args.jsons_dir}")
+
+    entries = find_page_files(args.jsons_dir, args.stem)
+    if not entries:
+        raise SystemExit("No checkpoint files were found.")
+
+    stems = {stem for stem, _, _ in entries}
+    if args.stem is None:
+        if len(stems) > 1:
+            raise SystemExit(
+                "Multiple stems detected. Specify --stem to select which document to merge: "
+                + ", ".join(sorted(stems))
+            )
+        args.stem = stems.pop()
+    else:
+        missing = [stem for stem in stems if stem != args.stem]
+        if missing:
+            LOG.warning(
+                "Ignoring %d file(s) because their stem does not match --stem=%s",
+                len(missing),
+                args.stem,
+            )
+
+    page_leads_path = args.page_leads_path
+    if args.page_leads:
+        if page_leads_path is None:
+            if args.stem is None:
+                raise SystemExit("Cannot infer page_leads_path without a stem.")
+            page_leads_path = args.jsons_dir / f"{args.stem}.page_leads.json"
+        LOG.info("Page-lead sidecar will be written to %s", page_leads_path)
+    else:
+        if page_leads_path is not None:
+            LOG.warning("--page_leads_path provided without --page_leads; ignoring the path.")
+        page_leads_path = None
+
+    merge_pages(entries, args.page_leads, page_leads_path, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/merge_utils.py
+++ b/merge_utils.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Shared helpers for merging page-level JSON checkpoints."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+CONT_SENTINEL_ID = "__CONT__"
+PAGE_SENTINEL_ID = "__PAGE__"
+
+
+def apply_continuation_if_any(page_objs: List[dict], merged: List[dict]) -> List[dict]:
+    """Handle a leading continuation sentinel for the current page.
+
+    When a page begins mid-entry, the generation step prepends a continuation
+    sentinel (``__CONT__``). The sentinel carries additional ``scope.notes``
+    lines that should be appended to the trailing real concept from previous
+    pages. After applying the carry-over notes the sentinel is removed.
+
+    Args:
+        page_objs: Objects loaded for the current page.
+        merged: Accumulated objects from prior pages; used to locate the last
+            real concept that should receive the continuation notes.
+
+    Returns:
+        The page objects with the sentinel removed (if present).
+    """
+    if not page_objs:
+        return page_objs
+
+    first = page_objs[0]
+    if not (isinstance(first, dict) and first.get("id") == CONT_SENTINEL_ID and first.get("notation") == CONT_SENTINEL_ID):
+        return page_objs
+
+    scope = first.get("scope") or {}
+    cont_notes: List[str] = []
+    if isinstance(scope, dict):
+        notes_val = scope.get("notes")
+        if isinstance(notes_val, list):
+            cont_notes = notes_val
+
+    if cont_notes:
+        for i in range(len(merged) - 1, -1, -1):
+            candidate = merged[i]
+            if not isinstance(candidate, dict):
+                continue
+            if candidate.get("id") in (CONT_SENTINEL_ID, PAGE_SENTINEL_ID):
+                continue
+
+            tgt_scope = candidate.setdefault("scope", {})
+            if not isinstance(tgt_scope, dict):
+                tgt_scope = {}
+                candidate["scope"] = tgt_scope
+
+            notes = tgt_scope.setdefault("notes", [])
+            if isinstance(notes, list):
+                notes.extend(cont_notes)
+            else:
+                tgt_scope["notes"] = cont_notes
+            break
+
+    return page_objs[1:]
+
+
+def is_page_lead_sentinel(obj: dict, page_number: Optional[int] = None, img_name: Optional[str] = None) -> bool:
+    """Return True if *obj* represents a page-lead (``__PAGE__``) sentinel."""
+    if not isinstance(obj, dict):
+        return False
+    if obj.get("id") != PAGE_SENTINEL_ID or obj.get("notation") != PAGE_SENTINEL_ID:
+        return False
+    if obj.get("type") != "Concept":
+        return False
+
+    if page_number is not None and obj.get("page") != page_number:
+        return False
+
+    if img_name is not None:
+        src = obj.get("source", {})
+        if not isinstance(src, dict) or src.get("fileName") != img_name:
+            return False
+
+    return True
+
+
+def apply_page_lead_if_any(
+    page_objs: List[dict],
+    page_number: int,
+    img_name: Optional[str],
+    page_leads: Dict[int, dict],
+) -> List[dict]:
+    """Capture and drop a leading ``__PAGE__`` sentinel if present.
+
+    The sentinel is stored inside *page_leads* under the 1-based page number.
+    When no sentinel is present, *page_objs* is returned unchanged.
+    """
+    if not page_objs:
+        return page_objs
+
+    first = page_objs[0]
+    if is_page_lead_sentinel(first, page_number, img_name):
+        page_leads[page_number] = first
+        return page_objs[1:]
+    return page_objs
+
+
+__all__ = [
+    "apply_continuation_if_any",
+    "apply_page_lead_if_any",
+    "is_page_lead_sentinel",
+    "CONT_SENTINEL_ID",
+    "PAGE_SENTINEL_ID",
+]


### PR DESCRIPTION
## Summary
- extract the continuation and page-lead sentinel handling into a reusable helper module
- add a merge_jsons CLI that assembles page-level checkpoint JSON into a final file and optional sidecar
- update gemini.py to import and use the shared helpers

## Testing
- python -m compileall merge_utils.py merge_jsons.py gemini.py
- python merge_jsons.py --help

------
https://chatgpt.com/codex/tasks/task_e_68cfeb9f30408330aa0f508e8f258e08