### PR TITLE
Strip viewer down to simple embed

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DDC 23rd Edition Design</title>
+  <style>
+    :root {
+      color-scheme: dark;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #000;
+      color: #fff;
+      font-family: "Courier New", Courier, monospace;
+    }
+
+    main {
+      width: min(960px, 100%);
+      padding: 2.5rem 1.5rem 3rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 2.5rem;
+    }
+
+    #menu {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.75rem;
+      text-align: center;
+    }
+
+    section[hidden] {
+      display: none !important;
+    }
+
+    .ascii-banner {
+      margin: 0;
+      white-space: pre;
+      font-size: clamp(0.75rem, 1.8vw, 1.2rem);
+      line-height: 1.4;
+    }
+
+    .spinner-line {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      font-size: 0.95rem;
+    }
+
+    .spinner {
+      display: inline-block;
+      min-width: 1ch;
+    }
+
+    .menu-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 1rem;
+    }
+
+    button {
+      background: #000;
+      color: #fff;
+      border: 1px solid #fff;
+      padding: 0.75rem 2.5rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      font-size: 0.95rem;
+      cursor: pointer;
+      transition: background 0.18s ease, color 0.18s ease;
+    }
+
+    button:hover,
+    button:focus-visible {
+      background: #fff;
+      color: #000;
+      outline: none;
+    }
+
+    #viewer {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.25rem;
+    }
+
+    .back-tip {
+      text-transform: uppercase;
+      letter-spacing: 0.2em;
+      font-size: 0.75rem;
+    }
+
+    .viewer-frame {
+      width: min(960px, 95vw);
+      height: min(70vh, 600px);
+      border: none;
+      background: transparent;
+    }
+
+    iframe {
+      width: 100%;
+      height: 100%;
+      border: none;
+      background: transparent;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section id="menu">
+      <pre class="ascii-banner">
+ __          __  _                               _        _   _             _           _
+ \ \        / / | |                            | |      | | (_)           | |         | |
+  \ \  /\  / /__| | ___ ___  _ __ ___   ___  __| |   ___| |_ _  ___  _ __ | |__   ___ | |
+   \ \/  \/ / _ \ |/ __/ _ \| '_ ` _ \ / _ \/ _` |  / __| __| |/ _ \| '_ \| '_ \ / _ \| |
+    \  /\  /  __/ | (_| (_) | | | | | |  __/ (_| | | (__| |_| | (_) | | | | | | | (_) | |
+     \/  \/ \___|_|\___\___/|_| |_| |_|\___|\__,_|  \___|\__|_|\___/|_| |_|_| |_|\___/|_|
+      </pre>
+      <div class="spinner-line">
+        <span id="spinner" class="spinner">|</span>
+        <span>WELCOME TO THE DDC 23RD EDITION DESIGN PAGE</span>
+      </div>
+      <div class="menu-buttons">
+        <button type="button" id="see-schedules">Schedules</button>
+        <button type="button" id="see-tables">Tables</button>
+      </div>
+    </section>
+    <section id="viewer" hidden>
+      <div class="back-tip">Press 0 to go back to menu</div>
+      <iframe id="viewer-frame" class="viewer-frame" title="DDC Viewer" sandbox="allow-scripts allow-same-origin"></iframe>
+    </section>
+  </main>
+  <script>
+    (function () {
+      const spinner = document.getElementById("spinner");
+      const frames = ["|", "/", "-", "\\"];
+      let index = 0;
+      setInterval(() => {
+        index = (index + 1) % frames.length;
+        spinner.textContent = frames[index];
+      }, 140);
+
+      const menu = document.getElementById("menu");
+      const viewer = document.getElementById("viewer");
+      const iframe = document.getElementById("viewer-frame");
+      function show(view) {
+        const file = view === "tables" ? "tables_graph.html" : "hierarchy_graph.html";
+        iframe.src = file;
+        menu.hidden = true;
+        viewer.hidden = false;
+      }
+
+      function backToMenu() {
+        iframe.src = "";
+        viewer.hidden = true;
+        menu.hidden = false;
+      }
+
+      document.getElementById("see-schedules").addEventListener("click", () => show("schedules"));
+      document.getElementById("see-tables").addEventListener("click", () => show("tables"));
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "0") {
+          backToMenu();
+        }
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove the "Now Showing" label so the schedules/tables view only shows the iframe and the back-to-menu tip
- make the embedded frame transparent with no surrounding border so the visualizations stand alone against the page background

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d162a38634833083ba5101feea1814